### PR TITLE
Externalize the values of the S3 bucket and Scholar url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 ir-exportq Queue
 ======================
 
-This queue will run daily to export all of the records in IR (https://scholar.colorado.edu) to an CSV file and upload it to S3 bucket.
+This queue task can run daily and exports all of the records in IR Scholar to a CSV file and uploads the CSV file to a S3 bucket.
+
+It requires 2 environmental variables to deteremine the destination S3 bucket and the Scholar url (without the ending '/') to query.
+  ***S3_BUCKET_IR_REPORT*** defaults to *cubl-ir-reports* if not set.
+  ***SCHOLAR_URL*** defaults to *https://scholar.colorado.edu* if not set.
 
 License
 -------


### PR DESCRIPTION
Allow environmental variables (EKS Secrets/config maps) to change the destination S3 bucket name and also the Scholar URL so that it can work on both test and production environments.