### PR TITLE
Support Celery v5

### DIFF
--- a/ir-exportq/tasks/tasks.py
+++ b/ir-exportq/tasks/tasks.py
@@ -1,4 +1,5 @@
-from celery.task import task
+from celery import Celery
+import celeryconfig
 import json
 import requests
 import csv
@@ -14,6 +15,8 @@ S3_DESTINATION_BUCKET = os.getenv("S3_BUCKET_IR_REPORT", "cubl-ir-reports")
 # The url for the Scholar app (without the ending '/')
 SCHOLAR_URL = os.getenv("SCHOLAR_URL", "https://scholar.colorado.edu")
 
+app = Celery()
+app.config_from_object(celeryconfig)
 
 workTypeDict = {
     'GraduateThesisOrDissertation': 'graduate_thesis_or_dissertations',
@@ -44,7 +47,7 @@ def uploadToS3(countRecords):
         return {'message': 'File is not exits'}
 
 
-@task()
+@app.task()
 def runExport():
     #url = 'https://scholar.colorado.edu/catalog.json?per_page=100&q=&search_field=all_fields'
     url = SCHOLAR_URL + '/catalog.json?per_page=100&q=&search_field=all_fields'


### PR DESCRIPTION
# PR Title
Support Celery v5 API changes

## Summary
This PR updates the **IR Export Report Celery Task** to work with the new Celery v5 API.

## Change Log
1. Update to follow changes in v5 of Celery API specifically removal of the celery.task module and importing directly from the Celery module instead.  This follows the changes made to the [sample cybercom task](https://github.com/cybercommons/cybercomq/tree/celery5).

## Breaking Changes
- This version of the IR Export Report task requires at least version v5.0 of Celery and has been tested with Celery v5.2.7.